### PR TITLE
Fix Node compatibility checks

### DIFF
--- a/block_programming_visualizer.js
+++ b/block_programming_visualizer.js
@@ -1,9 +1,15 @@
-// Global değişkenler - diğer dosyalardan erişilebilmesi için window objesine ekle
-window.canvas = null;
-window.ctx = null;
-window.x = 0;
-window.y = 0;
-window.angle = 0;
+(function() {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+        console.warn('block_programming_visualizer.js requires a browser environment.');
+        return;
+    }
+
+    // Global değişkenler - diğer dosyalardan erişilebilmesi için window objesine ekle
+    window.canvas = null;
+    window.ctx = null;
+    window.x = 0;
+    window.y = 0;
+    window.angle = 0;
 
 // Path ve karakter başlangıç
 const path = [
@@ -162,3 +168,4 @@ if (document.readyState === 'complete' || document.readyState === 'interactive')
 }
 
 console.log('block_programming_visualizer.js yüklendi');
+})();

--- a/script.js
+++ b/script.js
@@ -1,4 +1,10 @@
 // Oyun değişkenleri
+const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
+const storage = isBrowser && window.localStorage ? window.localStorage : {
+    getItem: () => null,
+    setItem: () => {}
+};
+
 let currentLevel = 1;
 let unlockedLevels = 1; // Başlangıçta sadece 1. seviye açık
 const levels = [
@@ -1108,7 +1114,7 @@ function setupPaintCanvas() {
 
 // Kullanıcı ilerlemesini kaydet
 function saveProgress() {
-    localStorage.setItem('ressamRobotProgress', JSON.stringify({
+    storage.setItem('ressamRobotProgress', JSON.stringify({
         unlockedLevels: unlockedLevels,
         currentLevel: currentLevel
     }));
@@ -1116,7 +1122,7 @@ function saveProgress() {
 
 // Kullanıcı ilerlemesini yükle
 function loadProgress() {
-    const savedProgress = localStorage.getItem('ressamRobotProgress');
+    const savedProgress = storage.getItem('ressamRobotProgress');
     if (savedProgress) {
         const progress = JSON.parse(savedProgress);
         unlockedLevels = progress.unlockedLevels;
@@ -1125,7 +1131,11 @@ function loadProgress() {
 }
 
 // Oyunu başlat
-window.addEventListener('load', () => {
-    loadProgress();
-    initGame();
-});
+if (isBrowser) {
+    window.addEventListener('load', () => {
+        loadProgress();
+        initGame();
+    });
+} else {
+    console.warn('script.js is intended for the browser environment.');
+}


### PR DESCRIPTION
## Summary
- guard browser-only code in `script.js`
- wrap `block_programming_visualizer.js` in a browser check

## Testing
- `npm test` *(fails: could not find package.json)*
- `composer test` *(fails: composer not found)*

------
